### PR TITLE
Version/v8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: required
 
 mono: none
 
-dotnet: 2.2
+dotnet: 3.1
 
 branches:
   only:
@@ -36,5 +36,5 @@ matrix:
       dist: xenial
     - os: osx
       # Ref: https://docs.travis-ci.com/user/reference/osx
-      dotnet: 2.2.104
+      dotnet: 3.1.0
       osx_image: xcode10.1

--- a/nuspec/Piranha.AspNetCore.Identity.MySQL.nuspec
+++ b/nuspec/Piranha.AspNetCore.Identity.MySQL.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>Piranha.AspNetCore.Identity.MySQL</id>
     <title>Piranha AspNetCore Identity MySQL</title>
-    <version>7.0.0</version>
+    <version>8.0.0</version>
     <authors>Maik Müller, Håkan Edling</authors>
     <owners>Maik Müller</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Piranha CMS AspNetCore Identity provider for MySQL</description>
     <copyright>Copyright 2018-2019 (c) Maik Müller</copyright>
-    <tags>cms mvc aspnetcore netstandard</tags>
+    <tags>cms mvc aspnetcore</tags>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/piranhacms/piranha.core.mysql</projectUrl>
     <iconUrl>http://piranhacms.org/assets/twitter-shield.png</iconUrl>
@@ -17,14 +17,14 @@
       See the changelog available at: https://github.com/piranhacms/piranha.core.mysql/wiki/changelog
     </releaseNotes>
     <dependencies>
-      <group targetFramework=".NETStandard2.0">
-        <dependency id="Piranha.AspNetCore.Identity" version="[7.0.0,8.0.0)" />
-        <dependency id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" version="2.2.0" />
-        <dependency id="Pomelo.EntityFrameworkCore.MySql" version="2.2.0" />
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="Piranha.AspNetCore.Identity" version="[8.0.0,9.0.0)" />
+        <dependency id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" version="3.1.0" />
+        <dependency id="Pomelo.EntityFrameworkCore.MySql" version="3.1.0-rc1.final" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\Piranha.AspNetCore.Identity.MySQL\bin\Release\netstandard2.0\Piranha.AspNetCore.Identity.MySQL.dll" target="lib\netstandard2.0\Piranha.AspNetCore.Identity.MySQL.dll" />
+    <file src="..\src\Piranha.AspNetCore.Identity.MySQL\bin\Release\netcoreapp3.1\Piranha.AspNetCore.Identity.MySQL.dll" target="lib\netcoreapp3.1\Piranha.AspNetCore.Identity.MySQL.dll" />
   </files>
 </package>

--- a/nuspec/Piranha.AspNetCore.Identity.MySQL.nuspec
+++ b/nuspec/Piranha.AspNetCore.Identity.MySQL.nuspec
@@ -20,7 +20,7 @@
       <group targetFramework="netcoreapp3.1">
         <dependency id="Piranha.AspNetCore.Identity" version="[8.0.0,9.0.0)" />
         <dependency id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" version="3.1.0" />
-        <dependency id="Pomelo.EntityFrameworkCore.MySql" version="3.1.0-rc1.final" />
+        <dependency id="Pomelo.EntityFrameworkCore.MySql" version="3.1.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Piranha.AspNetCore.Identity.MySQL/Piranha.AspNetCore.Identity.MySQL.csproj
+++ b/src/Piranha.AspNetCore.Identity.MySQL/Piranha.AspNetCore.Identity.MySQL.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>7.0.0</Version>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Version>8.0.0</Version>
     <Company>Piranha CMS</Company>
     <AssemblyTitle>Piranha.AspNetCore.Identity.MySQL</AssemblyTitle>
     <RootNamespace>Piranha.AspNetCore.Identity.MySQL</RootNamespace>
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.0" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.2.0" />
-    <PackageReference Include="Piranha.AspNetCore.Identity" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.0-rc1.final" />
+    <PackageReference Include="Piranha.AspNetCore.Identity" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Piranha.AspNetCore.Identity.MySQL/Piranha.AspNetCore.Identity.MySQL.csproj
+++ b/src/Piranha.AspNetCore.Identity.MySQL/Piranha.AspNetCore.Identity.MySQL.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.0-rc1.final" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.0" />
     <PackageReference Include="Piranha.AspNetCore.Identity" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
These are the changes I needed to make to make it work with Piranha.Core 8 and dotnet core 3.1.

Tested: running piranha razor blog with mysql on both mac, win and linux.
Not tested (but updated): nuget package generation, travis build
Not tested (not considered): migrations

Note: Pomelo.EntityFrameworkCore.MySql went from -rc1.final to 3.1.0 just now.